### PR TITLE
Fix: remove invalid SMAC logging path

### DIFF
--- a/dacboenv/configs/env/opt/base.yaml
+++ b/dacboenv/configs/env/opt/base.yaml
@@ -13,10 +13,6 @@ dacboenv:
         n_workers: 1
         output_directory: ${outdir}/smac3_output
       smac_kwargs:
-        logging_level:
-          _target_: pathlib.Path
-          _args_:
-            - dacboenv/configs/logging/smac_internal.yaml
         dask_client: null
         overwrite: true
         initial_design:


### PR DESCRIPTION
The logging path is hardcoded in the configuration and, therefore, only valid in cases where code gets executed from inside this package.

Hydra does not provide the means to do this more dynamically, and one would have to build this path during runtime in Python. Therefor,e I have just removed it for now.