### PR TITLE
fix(action): correct three bugs in action space classes

### DIFF
--- a/dacboenv/env/action.py
+++ b/dacboenv/env/action.py
@@ -143,6 +143,8 @@ class WEITempoRLActionSpace(AbstractActionSpace):
         self, smac_instance: SMBO, step_durations: list[int] | None, param_levels: list[float] | None = None
     ) -> None:
         self._step_durations = list(step_durations) if step_durations is not None else [1, 5, 10]
+        if any(d <= 0 for d in self._step_durations):
+            raise ValueError(f"All step_durations must be > 0, got {self._step_durations}")
         self._param_levels = list(param_levels) if param_levels is not None else [0.0, 0.25, 0.5, 0.75, 1]
         super().__init__(smac_instance)
 
@@ -292,7 +294,7 @@ class AcqParameterActionSpace(AbstractActionSpace):
             elif action_val == 2:  # noqa: PLR2004
                 self._last += self._step_size
 
-            self._last = np.clip(self._last, amin=self._bounds[0], amax=self._bounds[1])
+            self._last = np.clip(self._last, self._bounds[0], self._bounds[1])
             param_val = self._last
         elif self._adjustment_type == "bucket":
             param_val = action_val + self._bounds[0]  # that value probably is below 0 so basically the offset
@@ -328,9 +330,9 @@ class AcqFunctionActionSpace(AbstractActionSpace):
         acquisition_functions : list[AbstractAcquisitionFunction] | None, optional
             List of acquisition function classes, by default None. If None, will be [EI, PI, UCB].
         """
-        super().__init__(smac_instance)
         _afs = [EI, PI, UCB] if acquisition_functions is None else acquisition_functions
         self._acq_fun_dict = dict(enumerate(_afs))
+        super().__init__(smac_instance)
 
     def _create_action(self) -> FunctionAction:
         """Create a FunctionAction representing the discrete selection of acquisition functions.


### PR DESCRIPTION
- AcqFunctionActionSpace: initialize _acq_fun_dict before calling super().__init__(), which triggers _create_action() that references it
- AcqParameterActionSpace: replace invalid amin=/amax= keyword args in np.clip() with positional arguments (dacboenv shouldd then supports numpy < 2 if I tested correctly) 
- WEITempoRLActionSpace: add validation that all step_durations are > 0